### PR TITLE
Correction in produce-detail.html

### DIFF
--- a/_includes/components/product-cards/product-details.html
+++ b/_includes/components/product-cards/product-details.html
@@ -25,7 +25,7 @@
     {% endfor %}
   </section>
 {% endif %}
-<p id="product-details-footer">
+<p id="product-details-footer" class="row">
   {% for resource in page.resources.spec-sheets.catalog %}
     <img src="{{ site.amazon-s3 }}{{ resource }}" alt="{{ page.title }}" class="img-center">
   {% endfor %}


### PR DESCRIPTION
A 'class = "row"' is added in the footer section, to prevent the "prices ..." legend from being merged with the feature section when there is no image in the footer.