### PR TITLE
Strip spaces from firebase-lang variable

### DIFF
--- a/_includes/components/firebase/ui.liquid
+++ b/_includes/components/firebase/ui.liquid
@@ -1,6 +1,7 @@
 {% capture firebase-lang %}
-  {{ site.lang |  slice: 0,2 | default: "en" }}
+  {{ site.lang | slice: 0,2 | default: "en" }}
 {% endcapture %}
+{% assign firebase-lang = firebase-lang | strip %}
 {% if firebase-lang == "es" %}
   {% assign firebase-lang = "es_419" %}
 {% endif %}

--- a/_includes/components/topbars/progressive.html
+++ b/_includes/components/topbars/progressive.html
@@ -1,6 +1,6 @@
 <div id="top-box">
-  <div class="container-fluid mx-xl-5">
-    <div class="custom">
+  <div class="container-fluid">
+    <div class="custom ml-xl-5 mx-xl-4">
       <div id="exchange-rates">
         {% if site.exchange-rates.usd %}
           {% include components/exchange-rates/progressive.html %}


### PR DESCRIPTION
Also fix error on margins @ topbar
 
Backtrace:
```
- External link 
https://www.gstatic.com/firebasejs/ui/2.5.1/firebase-ui-auth__  es .js failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: URL using bad/illegal format or missing URL
```