### PR TITLE
Make the breadcrumb extend all the viewport

### DIFF
--- a/_includes/components/breadcrumbs/bootstrap.html
+++ b/_includes/components/breadcrumbs/bootstrap.html
@@ -1,4 +1,4 @@
-<nav class="breadcrumb-component" aria-label="breadcrumb">
+<nav class="breadcrumb-component px-xl-5" aria-label="breadcrumb">
   <ol id="breadcrumb" class="breadcrumb">
     {% for level in (-1..page.categories.size) %}
       {% if forloop.first %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -19,7 +19,7 @@ layout: default
 {% include components/breadcrumbs/bootstrap.html %}
 
 <h2 id="{{ i18n-id }}" class="post {{ class }}">{% if i18n-title %}{{ i18n-title }}{% else %}{{ page.title }}{% endif %}</h2>
-<h3 id="{{ i18n-id }}" class="post {{ class }}">{% if i18n-subtitle %}{{ i18n-subtitle }}{% else %}{{ page.subtitle }}{% endif %}</h3>
+<h3 id="{{ i18n-id }}" class="post text-muted {{ class }}">{% if i18n-subtitle %}{{ i18n-subtitle }}{% else %}{{ page.subtitle }}{% endif %}</h3>
 
 <div class="post">
   <div id="sign-in-content"></div>

--- a/_sass/components/breadcrumbs/_bootstrap.scss
+++ b/_sass/components/breadcrumbs/_bootstrap.scss
@@ -1,5 +1,4 @@
 nav.breadcrumb-component {
-  max-width: 1200px;
   margin: auto;
 
   ol.breadcrumb {


### PR DESCRIPTION
This makes the `breadcrumb` extend all the viewport available as our new navbar