### PR TITLE
Fix hideMarkersOnLatLng() loop

### DIFF
--- a/_includes/components/maps/google-maps.js
+++ b/_includes/components/maps/google-maps.js
@@ -86,6 +86,7 @@
     for (var i = 0; i < markers.length; i++) {
       if (markers[i].position.lat() == lat && markers[i].position.lng() == lng) {
         cluster.removeMarker(markers[i]);
+        i--;
       }
     }
   }


### PR DESCRIPTION
When 2 or more empty map_url variables where empty... the loop had a bug that skipped the later, this will fix that 🐛.

 