### PR TITLE
 Implement relative_url to components used by the jekyll theme marketing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace :serve do
     begin
       puts "## Running: bundle exec jekyll serve --config _config-dev.yml --host 0.0.0.0"
       config_prod=YAML.load_file("_config.yml")
+      config_prod.merge!({ "baseurl" => nil })
       config_prod.each do |key, value|
         if key == "defaults"
           value[2].each do |key, value| # collections.radios.published = false
@@ -45,7 +46,12 @@ namespace :serve do
   task :prod do
     begin
       puts "## Running: bundle exec jekyll serve --host 0.0.0.0"
-      system "bundle exec jekyll serve --host 0.0.0.0"
+      config_prod=YAML.load_file("_config.yml")
+      config_prod.merge!({ "baseurl" => nil })
+      config_dev=File.new("_config-dev.yml","w")
+      config_dev.write(config_prod.to_h.to_yaml)
+      config_dev.close
+      system "bundle exec jekyll serve --config _config-dev.yml --host 0.0.0.0"
     rescue Exception => e
       puts e
       puts "\n## Shutting down server"

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: > # this means to ignore newlines until "keywords:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 keywords: Jekyll, GitHub Pages, theme, website, blog
-baseurl:
+baseurl: /jekyll-theme-marketing
 domain: converse.mx
 original: true
 lang: en_US

--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ description: > # this means to ignore newlines until "keywords:"
   Google search results) and in your feed.xml site description.
 keywords: Jekyll, GitHub Pages, theme, website, blog
 baseurl: /jekyll-theme-marketing
+destination: ./_site/jekyll-theme-marketing
 domain: converse.mx
 original: true
 lang: en_US

--- a/_includes/components/icons/bootstrap.html
+++ b/_includes/components/icons/bootstrap.html
@@ -1,11 +1,11 @@
 <div class="d-none d-sm-block order-lg-1" data-component="icons/bootstrap">
-  <a href="/search/">
+  <a href="{{ '/search/' | relative_url }}">
     <i class="fas fa-search" data-fa-transform="down-5"></i>
   </a>
-  <a href="/our-offices/">
+  <a href="{{ '/our-offices/' | relative_url }}">
     <i class="fas fa-map-marker-alt" data-fa-transform="down-5"></i>
   </a>
-  <a href="/contact/">
+  <a href="{{ '/contact/' | relative_url }}">
     <i class="fas fa-envelope" data-fa-transform="down-6 grow-2"></i>
   </a>
   <a href="tel:{{ site.address[0].phone[0].number }}">

--- a/_includes/components/icons/progressive.html
+++ b/_includes/components/icons/progressive.html
@@ -7,13 +7,13 @@
   </div> <!-- end search button -->
 
   <div class="location-header hidden-600"> <!-- start location button -->
-    <a href="/our-offices/">
+    <a href="{{ '/our-offices/' | relative_url }}">
       <i class="fas fa-map-marker-alt fa-lg" data-fa-transform="up-1"></i>
     </a>
   </div> <!-- end location button -->
 
   <div class="contact-header hidden-600"> <!-- start contact button -->
-    <a href="/contact/">
+    <a href="{{ '/contact/' | relative_url }}">
       <i class="fas fa-envelope fa-lg" data-fa-transform="grow-2"></i>
     </a>
   </div> <!-- end contact button -->

--- a/_includes/components/info-cards/card-deck.html
+++ b/_includes/components/info-cards/card-deck.html
@@ -1,7 +1,7 @@
 <div class="card-deck">
   {% for info-card in page.info-cards %}
     <div class="card pt-0 pt-sm-5 pt-lg-0" data-appear-animation="{{ info-card.animation }}">
-      <a href="{{ info-card.href }}">
+      <a href="{{ info-card.href | relative_url }}">
         <img src="{{ site.amazon-s3 }}/components/info-cards/card-deck/img/{{ info-card.img }}.png" class="card-img-top" alt="{{ info-card.title }}">
       </a>
       <div class="card-body">
@@ -9,7 +9,7 @@
         <p class="card-text">{{ info-card.desc }}</p>
       </div>
       <div class="card-footer text-right bg-white border-top-0">
-        <a class="btn btn-primary" href="{{ info-card.href }}">{{ info-card.button }}</a>
+        <a class="btn btn-primary" href="{{ info-card.href | relative_url }}">{{ info-card.button }}</a>
       </div>
     </div>
   {% endfor %}

--- a/_includes/components/megamenu/progressive.html
+++ b/_includes/components/megamenu/progressive.html
@@ -11,14 +11,14 @@
               {% if site.links.dropdown[sub-menu-name].disabled == null %}
                 <div class="box closed">
                   <h6 class="title">
-                    <a href="{{ sub-menu.name | split: ' => ' | last }}">
+                    <a href="{{ sub-menu.name | split: ' => ' | last | relative_url }}">
                       {{ site.data.i18n.catalog[menu.collection][site.lang][sub-menu-name].title | default: sub-menu-name }}
                     </a>
                   </h6>
                   <ul>
                     {% for sub-sub-menu in sub-menu.sub-menus %}
                       {% assign sub-sub-menu-name = sub-sub-menu | split: ' => ' | first %}
-                      <li><a href="{{ sub-sub-menu | split: ' => ' | last }}">{{ site.data.i18n.catalog[menu.collection][site.lang][sub-sub-menu-name].title | default: sub-sub-menu-name }}</a></li>
+                      <li><a href="{{ sub-sub-menu | split: ' => ' | last | relative_url }}">{{ site.data.i18n.catalog[menu.collection][site.lang][sub-sub-menu-name].title | default: sub-sub-menu-name }}</a></li>
                     {% endfor %}
                   </ul>
                 </div>

--- a/_includes/components/nav-items/bootstrap.html
+++ b/_includes/components/nav-items/bootstrap.html
@@ -1,14 +1,14 @@
 {% assign menu-name = menu.name | split: ' => ' | first %}
 {% if menu.sub-menus %}
   <li class="nav-item dropdown" data-component="nav-items/bootstrap">
-    <a class="nav-link dropdown-toggle" href="{{ menu.name | split: ' => ' | last }}" id="{{ menu-name }}-dropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-proofer-ignore>
+    <a class="nav-link dropdown-toggle" href="{{ menu.name | split: ' => ' | last | relative_url }}" id="{{ menu-name }}-dropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-proofer-ignore>
       {{ site.data.i18n.catalog[menu.collection][site.lang][menu-name].title | default: menu-name }}
     </a>
     <div class="dropdown-menu" aria-labelledby="{{ menu-name }}-dropdown">
       {% for sub-menu in menu.sub-menus %}
         {% assign sub-menu-name = sub-menu.name | split: ' => ' | first %}
         {% if site.links.dropdown[sub-menu-name].disabled == null %}
-          <a class="dropdown-item" href="{{ sub-menu.name | split: ' => ' | last }}">
+          <a class="dropdown-item" href="{{ sub-menu.name | split: ' => ' | last | relative_url }}">
             {{ site.data.i18n.catalog[menu.collection][site.lang][sub-menu-name].title | default: sub-menu-name }}
           </a>
         {% endif %}
@@ -16,7 +16,7 @@
     </div>
   </li>
 {% else %}
-  <a class="nav-item nav-link" href="{{ menu.name | split: ' => ' | last }}" data-component="nav-items/bootstrap">
+  <a class="nav-item nav-link" href="{{ menu.name | split: ' => ' | last | relative_url }}" data-component="nav-items/bootstrap">
     {{ site.data.i18n.catalog[menu.collection][site.lang][menu-name].title | default: menu-name }}
   </a>
 {% endif %}

--- a/_includes/components/product-cards/featured-product.html
+++ b/_includes/components/product-cards/featured-product.html
@@ -2,7 +2,7 @@
   <div class="card-group">
     {% for featured-product in page.featured-products %}
       <div class="card">
-        <a href="{{ featured-product.href }}">
+        <a href="{{ featured-product.href | relative_url }}">
           <img src="{{ site.amazon-s3 }}/components/product-cards/featured-product/img/{{ featured-product.img }}.png" class="card-img-top" alt="{{ featured-product.img }}" data-appear-animation="fadeInDown">
         </a>
         <div class="card-body" data-appear-animation="fadeInDown">

--- a/_includes/components/topbars/progressive.html
+++ b/_includes/components/topbars/progressive.html
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center pl-xl-5 px-xl-4">
 
-      <a class="text-light d-inline d-sm-none" href="/search/">
+      <a class="text-light d-inline d-sm-none" href="{{ '/search/' | relative_url }}">
         <i class="fas fa-search fa-lg" data-fa-transform="up-2 grow-4"></i>
       </a>
 
@@ -15,7 +15,7 @@
       <span id="sign-in">
         <span id="sign-in-welcome" class="d-none d-md-inline"></span>
         <strong id="sign-in-name" class="text-white"></strong>
-        <a id="login-button" class="btn btn-sm btn-primary text-white border-0 d-none" href="/">
+        <a id="login-button" class="btn btn-sm btn-primary text-white border-0 d-none" href="{{ '/' | relative_url }}">
           <i class="fas fa-sign-in-alt fa-lg" data-fa-transform="left-3"></i>
           <span style="font-size:12px">{{ site.data.i18n.common.firebase[site.lang].login.title }}</span>
         </a>

--- a/_includes/components/videos/background.html
+++ b/_includes/components/videos/background.html
@@ -14,7 +14,7 @@
           <p>
             {{ include.desc }}
           </p>
-          <a href="{{ include.href }}" class="btn btn-primary">{{ include.button }}</a>
+          <a href="{{ include.href | relative_url }}" class="btn btn-primary">{{ include.button }}</a>
         </div>
       </div>
     </div>

--- a/_pages/footer/support/gift-cards/gift-cards.md
+++ b/_pages/footer/support/gift-cards/gift-cards.md
@@ -21,7 +21,7 @@ resources:
             </a>
           </div>
           <div class="product-model">
-            <a href="{{ item.link | prepend: '/gift-cards' }}">{{ item.i18n[site.lang] | default: item.title }}</a>
+            <a href="{{ item.link | prepend: '/gift-cards' | relative_url }}">{{ item.i18n[site.lang] | default: item.title }}</a>
           </div>
         </div>
       {% endfor %}


### PR DESCRIPTION
This _PR_ also allow us to manage `baseurl` at _production_ but keeping _develop_ without it for easier testing.

The `htmlproofer` was configured to test using the `baseurl` path thru the `destination` config variable.

🎉 