### PR TITLE
Update the size of the catalog images dynamically

### DIFF
--- a/_includes/components/product-cards/product-details.js
+++ b/_includes/components/product-cards/product-details.js
@@ -1,0 +1,8 @@
+var img = new Image()
+img.src = '{{ site.amazon-s3 }}{{ resource }}'
+
+dummy = document
+    .getElementById("product-details-footer")
+    .getElementsByTagName('img')[{{ forloop.index0 }}]
+
+dummy.style.height = `${img.naturalHeight}px`

--- a/_includes/components/product-cards/product-details.js
+++ b/_includes/components/product-cards/product-details.js
@@ -13,7 +13,6 @@ async function updateHeight(image) {
         await new Promise(r => setTimeout(r, 1000));
         height = img.naturalHeight * dummy.clientWidth / 800
         dummy.style.height = `${height}px`
-        console.log(`${dummy.clientWidth}px x ${height}px`)
     } while (img.naturalHeight < 1)
 }
 

--- a/_includes/components/product-cards/product-details.js
+++ b/_includes/components/product-cards/product-details.js
@@ -1,7 +1,7 @@
 const images = Array.from(
     document
-            .getElementById("product-details-footer")
-            .getElementsByTagName('div')
+        .getElementById("product-details-footer")
+        .getElementsByTagName('div')
 )
 
 async function updateHeight(image) {

--- a/_includes/components/product-cards/product-details.js
+++ b/_includes/components/product-cards/product-details.js
@@ -1,15 +1,28 @@
-var img = new Image()
-img.src = '{{ site.amazon-s3 }}{{ resource }}'
+const images = Array.from(
+    document
+            .getElementById("product-details-footer")
+            .getElementsByTagName('div')
+)
 
-dummy = document
-    .getElementById("product-details-footer")
-    .getElementsByTagName('img')[{{ forloop.index0 }}]
-
-async function updateHeight() {
+async function updateHeight(image) {
     do {
+        var dummy = image.getElementsByTagName('img')[0]
+        var img = new Image()
+        img.src = image.style.backgroundImage.split('"')[1]
+
         await new Promise(r => setTimeout(r, 1000));
-        dummy.style.height = `${img.naturalHeight}px`
+        height = img.naturalHeight * dummy.clientWidth / 800
+        dummy.style.height = `${height}px`
+        console.log(`${dummy.clientWidth}px x ${height}px`)
     } while (img.naturalHeight < 1)
 }
 
-updateHeight()
+function updateCatalogImagesHeight() {
+    images.forEach(image => 
+        updateHeight(image)
+    );
+}
+
+window.addEventListener('resize', updateCatalogImagesHeight)
+
+updateCatalogImagesHeight()

--- a/_includes/components/product-cards/product-details.js
+++ b/_includes/components/product-cards/product-details.js
@@ -5,4 +5,11 @@ dummy = document
     .getElementById("product-details-footer")
     .getElementsByTagName('img')[{{ forloop.index0 }}]
 
-dummy.style.height = `${img.naturalHeight}px`
+async function updateHeight() {
+    do {
+        await new Promise(r => setTimeout(r, 1000));
+        dummy.style.height = `${img.naturalHeight}px`
+    } while (img.naturalHeight < 1)
+}
+
+updateHeight()

--- a/_includes/components/product-cards/product-details.liquid
+++ b/_includes/components/product-cards/product-details.liquid
@@ -36,11 +36,11 @@
       <div class="mx-auto" style="background-image: url({{ site.amazon-s3 }}{{ resource }});">
         <img src="{{ site.amazon-s3 }}/components/product-cards/product-details/img/dummy.png" title="{{ page.title }}" alt="{{ page.title }}" />
       </div>
-      <script type="text/javascript">
-        {% include components/product-cards/product-details.js %}
-      </script>
     {% endfor %}
   </section>
+  <script type="text/javascript">
+    {% include components/product-cards/product-details.js %}
+  </script>
 
   <section id="product-details-pricelists-notice" class="marketing-theme clean-view">
     <article>

--- a/_includes/components/product-cards/product-details.liquid
+++ b/_includes/components/product-cards/product-details.liquid
@@ -36,6 +36,9 @@
       <div class="mx-auto" style="background-image: url({{ site.amazon-s3 }}{{ resource }});">
         <img src="{{ site.amazon-s3 }}/components/product-cards/product-details/img/dummy.png" title="{{ page.title }}" alt="{{ page.title }}" />
       </div>
+      <script type="text/javascript">
+        {% include components/product-cards/product-details.js %}
+      </script>
     {% endfor %}
   </section>
 


### PR DESCRIPTION
We aren't constrained anymore by an obligated height on the catalog images.

They can have whatever height from 0 - 1200 px and they will display without blank areas between them.

🎉 

Related to https://github.com/cetinajero/jekyll-theme-marketing/pull/310

✌️ 