### PR TITLE
Exclude disabled products from search engine

### DIFF
--- a/_includes/components/search-engines/lunr.js
+++ b/_includes/components/search-engines/lunr.js
@@ -8,8 +8,7 @@ function generateData(){
   return [
     {% for collection in site.collections %}
       {% for page in collection.docs %}
-        {% assign url-size = page.url | size | minus: 2 %}
-        {% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: collection.label | remove_first: '-' %}
+        {% assign i18n-id = page.url | slugify | remove_first: collection.label | remove_first: '-' %}
         {% if site.links.product[i18n-id].disabled == null %}
           {% assign logo = site.domain | replace:'.',' ' | truncatewords: 1,"" | prepend: '/components/logos/progressive/img/' | prepend: site.amazon-s3 | append: '.png' %}
           {% assign page-image = page.image | slice: -12,8 %}

--- a/_includes/components/search-engines/lunr.js
+++ b/_includes/components/search-engines/lunr.js
@@ -8,26 +8,30 @@ function generateData(){
   return [
     {% for collection in site.collections %}
       {% for page in collection.docs %}
-        {% assign logo = site.domain | replace:'.',' ' | truncatewords: 1,"" | prepend: '/components/logos/progressive/img/' | prepend: site.amazon-s3 | append: '.png' %}
-        {% assign page-image = page.image | slice: -12,8 %}
-        {% if page-image == 'dummy-og' %}
-          {% assign page-image = logo %}
-        {% else %}
-          {% assign page-image = page.image %}
+        {% assign url-size = page.url | size | minus: 2 %}
+        {% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: collection.label | remove_first: '-' %}
+        {% if site.links.product[i18n-id].disabled == null %}
+          {% assign logo = site.domain | replace:'.',' ' | truncatewords: 1,"" | prepend: '/components/logos/progressive/img/' | prepend: site.amazon-s3 | append: '.png' %}
+          {% assign page-image = page.image | slice: -12,8 %}
+          {% if page-image == 'dummy-og' %}
+            {% assign page-image = logo %}
+          {% else %}
+            {% assign page-image = page.image %}
+          {% endif %}
+          {
+            "id": "{{ page.url | slugify }}",
+            "title": "{{ page.title | xml_escape }}",
+            "brand": "{{ page.brand | xml_escape }}",
+            "description": "{{ page.description | xml_escape }}",
+            "commercial": "{{ page.commercial | xml_escape }}",
+            "categories": "{{ page.categories | join: ' ' | replace: '-', ' ' }}",
+            "content": {{ page.content | strip_html | strip_newlines | jsonify }},
+            "url": "{{ page.url | xml_escape }}",
+            "image": "{{ page-image | default: logo | xml_escape }}",
+            "spec-sheets-text": "{{ page.resources.spec-sheets.text | join: ' ' | replace: '"', '' }}",
+            "spec-sheets-specs": "{{ page.resources.spec-sheets.specs | join: ' ' | replace: '{"name"=>"', '' | replace: '"', ' ' }}",
+          },
         {% endif %}
-        {
-          "id": "{{ page.url | slugify }}",
-          "title": "{{ page.title | xml_escape }}",
-          "brand": "{{ page.brand | xml_escape }}",
-          "description": "{{ page.description | xml_escape }}",
-          "commercial": "{{ page.commercial | xml_escape }}",
-          "categories": "{{ page.categories | join: ' ' | replace: '-', ' ' }}",
-          "content": {{ page.content | strip_html | strip_newlines | jsonify }},
-          "url": "{{ page.url | xml_escape }}",
-          "image": "{{ page-image | default: logo | xml_escape }}",
-          "spec-sheets-text": "{{ page.resources.spec-sheets.text | join: ' ' | replace: '"', '' }}",
-          "spec-sheets-specs": "{{ page.resources.spec-sheets.specs | join: ' ' | replace: '{"name"=>"', '' | replace: '"', ' ' }}",
-        },
       {% endfor %}
     {% endfor %}
   ];
@@ -116,4 +120,4 @@ function startApp() {
   }
 }
 
-//   startApp();
+startApp();

--- a/_layouts/grid.liquid
+++ b/_layouts/grid.liquid
@@ -1,40 +1,46 @@
 ---
 layout: page
 ---
-<script src="{{ '/assets/node_modules/isotope-layout-npm-3.0.6-ae267b8579/node_modules/isotope-layout/dist/isotope.pkgd.min.js' | relative_url }}"></script>
+{% assign url-size = page.url | size | minus: 2 %}
+{% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: page.collection | remove_first: '-' %}
+{% if site.links.product[i18n-id].disabled == null %}
+  <script src="{{ '/assets/node_modules/isotope-layout-npm-3.0.6-ae267b8579/node_modules/isotope-layout/dist/isotope.pkgd.min.js' | relative_url }}"></script>
 
-<div class="container-fluid" data-layout="grid">
-  <div class="row">
+  <div class="container-fluid" data-layout="grid">
+    <div class="row">
 
-    <div class="col-4 col-md-3 col-xl-2">
-      {% include components/filters/isotope.liquid %}
-    </div>
-
-    <div class="col-8 col-md-9 col-xl-10">
-      <div class="row grid">
-        {% assign collections = site.collections | where: "label", page.collection %}
-        {% for collection in collections %}
-          {% assign docs = collection.docs | where: "menu-father", page.menu-name %}
-          {% for doc in docs %}
-            {% assign url-size = doc.url | size | minus: 2 %}
-            {% assign i18n-id = doc.url | slice: 1,url-size | replace: '/', '-' | remove_first: collection.label | remove_first: '-' %}
-            {% assign i18n-title = site.data.i18n.catalog[collection.label][site.lang][i18n-id].title %}
-            {% if site.links.product[i18n-id].disabled == null %}
-              {% if doc.i18n[site.lang].description %}
-                {% assign i18n-description = doc.i18n[site.lang].description %}
-              {% else %}
-                {% assign i18n-description = site.data.i18n.catalog[collection.label][site.lang][i18n-id].desc %}
-              {% endif %}
-              {% include components/product-cards/progressive.liquid %}
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
+      <div class="col-4 col-md-3 col-xl-2">
+        {% include components/filters/isotope.liquid %}
       </div>
+
+      <div class="col-8 col-md-9 col-xl-10">
+        <div class="row grid">
+          {% assign collections = site.collections | where: "label", page.collection %}
+          {% for collection in collections %}
+            {% assign docs = collection.docs | where: "menu-father", page.menu-name %}
+            {% for doc in docs %}
+              {% assign url-size = doc.url | size | minus: 2 %}
+              {% assign i18n-id = doc.url | slice: 1,url-size | replace: '/', '-' | remove_first: collection.label | remove_first: '-' %}
+              {% assign i18n-title = site.data.i18n.catalog[collection.label][site.lang][i18n-id].title %}
+              {% if site.links.product[i18n-id].disabled == null %}
+                {% if doc.i18n[site.lang].description %}
+                  {% assign i18n-description = doc.i18n[site.lang].description %}
+                {% else %}
+                  {% assign i18n-description = site.data.i18n.catalog[collection.label][site.lang][i18n-id].desc %}
+                {% endif %}
+                {% include components/product-cards/progressive.liquid %}
+              {% endif %}
+            {% endfor %}
+          {% endfor %}
+        </div>
+      </div>
+
     </div>
+  </div> <!-- /container -->
 
-  </div>
-</div> <!-- /container -->
-
-<script type="text/javascript">
-  {% include components/filters/isotope.js %}
-</script>
+  <script type="text/javascript">
+    {% include components/filters/isotope.js %}
+  </script>
+{% else %}
+  <script type="text/javascript">window.location.href = "/"</script>
+{% endif %}

--- a/_layouts/grid.liquid
+++ b/_layouts/grid.liquid
@@ -1,8 +1,7 @@
 ---
 layout: page
 ---
-{% assign url-size = page.url | size | minus: 2 %}
-{% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: page.collection | remove_first: '-' %}
+{% assign i18n-id = page.url | slugify | remove_first: page.collection | remove_first: '-' %}
 {% if site.links.product[i18n-id].disabled == null %}
   <script src="{{ '/assets/node_modules/isotope-layout-npm-3.0.6-ae267b8579/node_modules/isotope-layout/dist/isotope.pkgd.min.js' | relative_url }}"></script>
 
@@ -19,8 +18,7 @@ layout: page
           {% for collection in collections %}
             {% assign docs = collection.docs | where: "menu-father", page.menu-name %}
             {% for doc in docs %}
-              {% assign url-size = doc.url | size | minus: 2 %}
-              {% assign i18n-id = doc.url | slice: 1,url-size | replace: '/', '-' | remove_first: collection.label | remove_first: '-' %}
+              {% assign i18n-id = doc.url | slugify | remove_first: collection.label | remove_first: '-' %}
               {% assign i18n-title = site.data.i18n.catalog[collection.label][site.lang][i18n-id].title %}
               {% if site.links.product[i18n-id].disabled == null %}
                 {% if doc.i18n[site.lang].description %}

--- a/_layouts/page.liquid
+++ b/_layouts/page.liquid
@@ -4,8 +4,7 @@ layout: default
 {% if page.layout == "product" %}
   {% assign class = 'd-none' %}
 {% else %}
-  {% assign url-size = page.url | size | minus: 2 %}
-  {% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: page.collection | remove_first: '-' %}
+  {% assign i18n-id = page.url | slugify | remove_first: page.collection | remove_first: '-' %}
   {% if i18n-id == "" %}{% assign i18n-id = page.collection %}{% endif %}
   {% if page.collection == 'pages' %}
     {% assign i18n-title = site.data.i18n.common[page.collection][site.lang][i18n-id].title %}

--- a/_layouts/product.liquid
+++ b/_layouts/product.liquid
@@ -14,8 +14,7 @@ special-offers:
   margin: 0.25
   dpi: 300
 ---
-{% assign url-size = page.url | size | minus: 2 %}
-{% assign i18n-id = page.url | slice: 1,url-size | replace: '/', '-' | remove_first: page.collection | remove_first: '-' %}
+{% assign i18n-id = page.url | slugify | remove_first: page.collection | remove_first: '-' %}
 {% if site.links.product[i18n-id].disabled == null %}
   <script src="{{ '/assets/node_modules/jspdf-npm-1.5.3-a947af654e/node_modules/jspdf/dist/jspdf.min.js' | relative_url }}"></script>
   {% if page.i18n[site.lang].title %}


### PR DESCRIPTION
This PR excludes the `config.yml`'s disabled products from:

- [x] the [lunr.js](https://lunrjs.com) search engine, and
- [x]  the `grid` layout

Aside: migrated from `url-size` variable to the [liquid's filter](https://jekyllrb.com/docs/liquid/filters/) `slugify`

---

Higly related to https://github.com/cetinajero/jekyll-theme-marketing/pull/48