### PR TITLE
Fix dependabot's "Couldn't find Ruby version!"

### DIFF
--- a/jekyll-theme-marketing.gemspec
+++ b/jekyll-theme-marketing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     f.match(gemfiles)
   end
 
-  spec.required_ruby_version = '2.5.8'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_runtime_dependency 'jekyll', '~> 3.6'
 


### PR DESCRIPTION
Relax a little bit the required ruby version to 2.5.x, this was needed due to the current dependabot's ruby version for 2.5.x is 2.5.6

Ref: [dependabot/dependabot-core@4b74834 (/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb#L11)](https://github.com/dependabot/dependabot-core/blob/4b74834fd6f8af78793d0780559d5c8df3372b1c/bundler/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb#L11)

Tracelog:

```
updater | ERROR <job_42956090> Couldn't find Ruby version!
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:56:in `ruby_version'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/file_updater/ruby_requirement_setter.rb:28:in `rewrite'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker/file_preparer.rb:254:in `block in lock_ruby_version'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker/file_preparer.rb:252:in `each'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker/file_preparer.rb:252:in `lock_ruby_version'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker/file_preparer.rb:170:in `gemfile_content_for_update_check'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker/file_preparer.rb:61:in `prepared_dependency_files'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker.rb:388:in `prepared_dependency_files'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker.rb:364:in `latest_version_finder'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker.rb:182:in `latest_version_details'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/vendor/ruby/2.6.0/gems/dependabot-bundler-0.118.10/lib/dependabot/bundler/update_checker.rb:20:in `latest_version'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:278:in `log_checking_for_update'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:164:in `check_and_create_pull_request'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:65:in `check_and_create_pr_with_error_handling'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `block in run'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `each'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/updater.rb:51:in `run'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/update_files_job.rb:16:in `perform_job'
updater | ERROR <job_42956090> /home/dependabot/dependabot-updater/lib/dependabot/base_job.rb:29:in `run'
updater | ERROR <job_42956090> bin/update_files.rb:21:in `<main>'
```

✌️ 