### PR TITLE
Pin Ruby version

### DIFF
--- a/jekyll-theme-marketing.gemspec
+++ b/jekyll-theme-marketing.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     f.match(gemfiles)
   end
 
-  spec.required_ruby_version = '~> 2.7.3'
+  spec.required_ruby_version = '2.7.3'
 
   spec.add_runtime_dependency 'jekyll', '~> 3.6'
 


### PR DESCRIPTION
Fixes: https://github.com/cetinajero/jekyll-theme-marketing/network/updates/142251417

Backtrace:

```
updater | ERROR <job_142251417> Error processing bump (Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound)
updater | ERROR <job_142251417> Dependabot::Bundler::FileUpdater::RubyRequirementSetter::RubyVersionNotFound
```

✌🏼 