### PR TITLE
Move all head elements to the head tag

### DIFF
--- a/_layouts/default.liquid
+++ b/_layouts/default.liquid
@@ -7,11 +7,11 @@
     {% seo %}
     {% include components/meta/progressive.liquid %}
     {% include components/scripts/head.liquid %}
-    {% include components/chats/whatsapp.liquid %}
     {% include components/firebase/sdk.liquid %}
     {% include components/fonts/google.html %}
     {% include components/stylesheets/progressive.liquid %}
     {% include components/analytics/google-tag.liquid %}
+    {% include components/chats/whatsapp.liquid %}
 
   </head>
 


### PR DESCRIPTION
The whatsapp component was causing some head tags to be incrusted into the body. Now that the Whatsapp component is the last one... we had fixed this issue.

✌🏼 